### PR TITLE
Use an event handle to check for pending SimConnect messages

### DIFF
--- a/FSUIPC_WAPI/WASMIF.h
+++ b/FSUIPC_WAPI/WASMIF.h
@@ -87,7 +87,6 @@ class WASMIF
 		void DispatchProc(SIMCONNECT_RECV* pData, DWORD cbData);
 		void ConfigTimer();
 		void RequestDataTimer();
-		volatile  HANDLE hThread = NULL;
 		DWORD WINAPI SimConnectStart();
 		void SimConnectEnd();
 		const char* getEventString(int eventNo);
@@ -97,6 +96,8 @@ class WASMIF
 	private:
 		static WASMIF* m_Instance;
 		HANDLE  hSimConnect;
+		volatile HANDLE hThread = nullptr;
+		HANDLE hSimEventHandle = nullptr;
 		int quit, noLvarCDAs, noHvarCDAs, startEventNo, lvarUpdateFrequency;
 		HANDLE configTimerHandle = nullptr;
 		HANDLE requestTimerHandle = nullptr;


### PR DESCRIPTION
It just seems cleaner this way to me.

Could probably do away with the thread altogether, but would need to refactor the startup routine a bit since `start()` needs to return something.

My local git had a minor conflict in the `.h` when merging this over top of the first PR (and vice versa), but GitHub is sometimes smarter it seems, so maybe it'll be OK.

Thanks,
-Max
